### PR TITLE
feat(live-source-agent): added LiveSourceAgent

### DIFF
--- a/src/services/live-source-agent/live.source.agent.service.ts
+++ b/src/services/live-source-agent/live.source.agent.service.ts
@@ -1,0 +1,392 @@
+import {
+  LiveSourceAgentConfig,
+  PinnedSource,
+  PinSourceInput,
+  PinResult,
+  UnpinResult,
+  InjectedContext,
+  InjectContextOptions,
+  LiveSourceStatusBarState,
+  LiveSourceCrawlerAdapter,
+  LiveSourceIndexAdapter,
+  LiveSourceEmbeddingAdapter,
+  LiveSourceStateAdapter,
+  LiveSourceProgressAdapter,
+  LiveSourceStatusBarAdapter,
+  LiveSourceError,
+  PINNED_SOURCE_SYSTEM_PREFIX,
+  STATUS_BAR_PREFIX,
+  MAX_PINNED_SOURCES,
+  DEFAULT_CRAWL_DEPTH,
+  DEFAULT_MAX_PAGES,
+  DEFAULT_PRIORITY_WEIGHT,
+} from './live.source.agent.types';
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function deriveLabelFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname + (parsed.pathname !== '/' ? parsed.pathname.replace(/\/$/, '') : '');
+  } catch {
+    return url.slice(0, 60);
+  }
+}
+
+function deriveLabelFromFilename(filename: string): string {
+  const base = filename.split('/').pop() ?? filename;
+  return base.replace(/\.[^.]+$/, '');
+}
+
+function generateId(): string {
+  return crypto.randomUUID();
+}
+
+export class LiveSourceAgent {
+  private readonly _maxSources: number;
+  private readonly _priorityWeight: number;
+  private readonly _crawlDepth: number;
+  private readonly _maxPages: number;
+  private readonly _topKPerSource: number;
+  private readonly _maxInjectedTokens: number;
+  private readonly _log: boolean;
+
+  private _sources: PinnedSource[] = [];
+  private _loaded = false;
+
+  constructor(
+    config: LiveSourceAgentConfig,
+    private readonly _crawlerAdapter: LiveSourceCrawlerAdapter,
+    private readonly _indexAdapter: LiveSourceIndexAdapter,
+    private readonly _embeddingAdapter: LiveSourceEmbeddingAdapter,
+    private readonly _stateAdapter: LiveSourceStateAdapter,
+    private readonly _statusBarAdapter?: LiveSourceStatusBarAdapter
+  ) {
+    this._maxSources = config.maxPinnedSources ?? MAX_PINNED_SOURCES;
+    this._priorityWeight = config.priorityWeight ?? DEFAULT_PRIORITY_WEIGHT;
+    this._crawlDepth = config.crawlDepth ?? DEFAULT_CRAWL_DEPTH;
+    this._maxPages = config.maxPages ?? DEFAULT_MAX_PAGES;
+    this._topKPerSource = config.topKPerSource ?? 3;
+    this._maxInjectedTokens = config.maxInjectedTokens ?? 2000;
+    this._log = config.enableLogging ?? true;
+  }
+
+  async pinSource(
+    input: PinSourceInput,
+    progressAdapter?: LiveSourceProgressAdapter
+  ): Promise<PinResult> {
+    // Input validation
+    if (input.type === 'url') {
+      if (!input.url || !input.url.trim()) {
+        throw new LiveSourceError('URL must not be empty.', 'INVALID_INPUT', input.url);
+      }
+      try {
+        const parsed = new URL(input.url);
+        if (!['http:', 'https:'].includes(parsed.protocol)) {
+          throw new Error('bad protocol');
+        }
+      } catch {
+        throw new LiveSourceError(
+          `Invalid URL: "${input.url}". Must be a valid http or https URL.`,
+          'INVALID_INPUT',
+          input.url
+        );
+      }
+    } else {
+      if (!input.buffer || input.buffer.length === 0) {
+        throw new LiveSourceError('PDF buffer must not be empty.', 'INVALID_INPUT');
+      }
+      if (!input.filename || !input.filename.trim()) {
+        throw new LiveSourceError('PDF filename must not be empty.', 'INVALID_INPUT');
+      }
+    }
+
+    await this._ensureLoaded();
+
+    const sourceRef = input.type === 'url' ? input.url : input.filename;
+    const label =
+      (input as { label?: string }).label ??
+      (input.type === 'url'
+        ? deriveLabelFromUrl(input.url)
+        : deriveLabelFromFilename(input.filename));
+
+    const existing = this._sources.find((s) => s.active && s.sourceRef === sourceRef);
+    const isRefresh = !!existing;
+
+    if (!isRefresh) {
+      const activeSources = this._sources.filter((s) => s.active);
+      if (activeSources.length >= this._maxSources) {
+        throw new LiveSourceError(
+          `Maximum pinned sources reached (${this._maxSources}). Unpin one before adding a new source.`,
+          'MAX_SOURCES_REACHED',
+          sourceRef
+        );
+      }
+    }
+
+    const start = Date.now();
+
+    progressAdapter?.report(`Crawling ${label}…`, 10);
+    let chunks: Array<{
+      content: string;
+      sourceRef: string;
+      sourceType: 'url' | 'pdf';
+      chunkIndex: number;
+      tokenCount: number;
+    }>;
+
+    try {
+      if (input.type === 'url') {
+        chunks = await this._crawlerAdapter.crawlUrl(input.url, {
+          depth: this._crawlDepth,
+          maxPages: this._maxPages,
+        });
+      } else {
+        chunks = await this._crawlerAdapter.parsePdf(input.buffer, input.filename);
+      }
+    } catch (err) {
+      throw new LiveSourceError(
+        `Failed to crawl/parse source "${label}".`,
+        'CRAWL_FAILED',
+        sourceRef,
+        err
+      );
+    }
+
+    if (chunks.length === 0) {
+      throw new LiveSourceError(
+        `No content could be extracted from "${label}". The source may be empty or unsupported.`,
+        'CRAWL_FAILED',
+        sourceRef
+      );
+    }
+
+    progressAdapter?.report(`Indexing ${chunks.length} chunks…`, 40);
+
+    const sessionId = isRefresh ? existing!.sessionId : `live-${generateId()}`;
+    let indexName: string;
+
+    try {
+      const session = await this._indexAdapter.createSession(sessionId, label);
+      indexName = session.indexName;
+    } catch (err) {
+      throw new LiveSourceError(
+        `Failed to create search index for "${label}".`,
+        'INDEX_FAILED',
+        sourceRef,
+        err
+      );
+    }
+
+    let uploaded = 0;
+    try {
+      const result = await this._indexAdapter.upsertChunks(sessionId, chunks);
+      uploaded = result.uploaded;
+    } catch (err) {
+      throw new LiveSourceError(
+        `Failed to index chunks for "${label}".`,
+        'INDEX_FAILED',
+        sourceRef,
+        err
+      );
+    }
+
+    progressAdapter?.report(`Indexed ${uploaded} chunks.`, 40);
+
+    const totalTokens = chunks.reduce((s, c) => s + c.tokenCount, 0);
+    const pagesCrawled = input.type === 'url' ? new Set(chunks.map((c) => c.sourceRef)).size : 0;
+
+    const record: PinnedSource = {
+      id: isRefresh ? existing!.id : generateId(),
+      label,
+      sourceRef,
+      sourceType: input.type,
+      sessionId,
+      indexName,
+      chunkCount: uploaded,
+      totalTokens,
+      pinnedAt: isRefresh ? existing!.pinnedAt : new Date().toISOString(),
+      priorityWeight: this._priorityWeight,
+      active: true,
+    };
+
+    if (isRefresh) {
+      this._sources = this._sources.map((s) => (s.id === existing!.id ? record : s));
+    } else {
+      this._sources = [...this._sources, record];
+    }
+
+    await this._stateAdapter.save(this._sources);
+    this._updateStatusBar();
+
+    if (this._log) {
+      console.log(
+        `[LiveSourceAgent] Pinned "${label}" — ${uploaded} chunks, ${pagesCrawled} pages, ${Date.now() - start}ms`
+      );
+    }
+
+    progressAdapter?.report(`Done. "${label}" is now pinned.`, 10);
+
+    return {
+      source: record,
+      refreshed: isRefresh,
+      chunksIndexed: uploaded,
+      pagesCrawled,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  async unpinSource(id: string): Promise<UnpinResult> {
+    await this._ensureLoaded();
+
+    const source = this._sources.find((s) => s.id === id);
+    if (!source) {
+      return { id, label: id, deleted: true, wasAlreadyGone: true };
+    }
+
+    // Delete the temp index (best-effort)
+    let wasAlreadyGone = false;
+    try {
+      await this._indexAdapter.deleteSession(source.sessionId);
+    } catch {
+      wasAlreadyGone = true;
+    }
+
+    // Mark inactive rather than removing, so history is preserved
+    this._sources = this._sources.map((s) => (s.id === id ? { ...s, active: false } : s));
+    await this._stateAdapter.save(this._sources);
+    this._updateStatusBar();
+
+    if (this._log) {
+      console.log(`[LiveSourceAgent] Unpinned "${source.label}"`);
+    }
+
+    return { id, label: source.label, deleted: true, wasAlreadyGone };
+  }
+
+  async unpinByRef(sourceRef: string): Promise<UnpinResult> {
+    await this._ensureLoaded();
+    const source = this._sources.find((s) => s.active && s.sourceRef === sourceRef);
+    if (!source) {
+      return { id: sourceRef, label: sourceRef, deleted: true, wasAlreadyGone: true };
+    }
+    return this.unpinSource(source.id);
+  }
+
+  async injectContext(options: InjectContextOptions): Promise<InjectedContext> {
+    await this._ensureLoaded();
+
+    const activeSources = this._sources.filter((s) => s.active);
+    if (activeSources.length === 0) {
+      return {
+        systemPrompt: options.baseSystemPrompt,
+        sourcesUsed: 0,
+        chunksInjected: 0,
+        addedTokens: 0,
+        hasInjection: false,
+      };
+    }
+
+    const topK = options.topKPerSource ?? this._topKPerSource;
+    const maxTokens = options.maxInjectedTokens ?? this._maxInjectedTokens;
+
+    let injectedText = PINNED_SOURCE_SYSTEM_PREFIX;
+    let chunksInjected = 0;
+    let sourcesUsed = 0;
+    let addedTokens = estimateTokens(PINNED_SOURCE_SYSTEM_PREFIX);
+
+    for (const source of activeSources) {
+      let hits: Array<{ content: string; score: number }> = [];
+      try {
+        hits = await this._indexAdapter.search(
+          source.sessionId,
+          options.query,
+          options.queryVector,
+          topK
+        );
+      } catch {
+        // Non-fatal — skip this source
+        continue;
+      }
+
+      if (hits.length === 0) continue;
+
+      const sourceHeader = `### ${source.label} (priority: ${source.priorityWeight}x)\n`;
+      const sourceText = hits.map((h) => h.content).join('\n\n');
+      const block = sourceHeader + sourceText + '\n\n';
+      const blockTokens = estimateTokens(block);
+
+      if (addedTokens + blockTokens > maxTokens) break;
+
+      injectedText += block;
+      addedTokens += blockTokens;
+      chunksInjected += hits.length;
+      sourcesUsed++;
+    }
+
+    if (sourcesUsed === 0) {
+      return {
+        systemPrompt: options.baseSystemPrompt,
+        sourcesUsed: 0,
+        chunksInjected: 0,
+        addedTokens: 0,
+        hasInjection: false,
+      };
+    }
+
+    const systemPrompt = injectedText + '---\n\n' + options.baseSystemPrompt;
+
+    return {
+      systemPrompt,
+      sourcesUsed,
+      chunksInjected,
+      addedTokens,
+      hasInjection: true,
+    };
+  }
+
+  async listPinnedSources(): Promise<PinnedSource[]> {
+    await this._ensureLoaded();
+    return this._sources.filter((s) => s.active);
+  }
+
+  async getSource(id: string): Promise<PinnedSource | null> {
+    await this._ensureLoaded();
+    return this._sources.find((s) => s.id === id) ?? null;
+  }
+
+  async getStatusBarState(): Promise<LiveSourceStatusBarState> {
+    await this._ensureLoaded();
+    const active = this._sources.filter((s) => s.active);
+    return { pinnedCount: active.length, labels: active.map((s) => s.label) };
+  }
+
+  buildStatusBarText(state: LiveSourceStatusBarState): string {
+    if (state.pinnedCount === 0) return '';
+    if (state.pinnedCount === 1) {
+      return `${STATUS_BAR_PREFIX} ${state.labels[0]} pinned`;
+    }
+    return `${STATUS_BAR_PREFIX} ${state.pinnedCount} docs pinned`;
+  }
+
+  private async _ensureLoaded(): Promise<void> {
+    if (this._loaded) return;
+    this._sources = await this._stateAdapter.load();
+    this._loaded = true;
+  }
+
+  private _updateStatusBar(): void {
+    if (!this._statusBarAdapter) return;
+    const active = this._sources.filter((s) => s.active);
+    if (active.length === 0) {
+      this._statusBarAdapter.clear();
+    } else {
+      this._statusBarAdapter.update({
+        pinnedCount: active.length,
+        labels: active.map((s) => s.label),
+      });
+    }
+  }
+}

--- a/src/services/live-source-agent/live.source.agent.test.ts
+++ b/src/services/live-source-agent/live.source.agent.test.ts
@@ -1,0 +1,1080 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { LiveSourceAgent } from './live.source.agent.service';
+import {
+  LiveSourceAgentConfig,
+  PinnedSource,
+  LiveSourceCrawlerAdapter,
+  LiveSourceIndexAdapter,
+  LiveSourceEmbeddingAdapter,
+  LiveSourceStateAdapter,
+  LiveSourceStatusBarAdapter,
+  LiveSourceProgressAdapter,
+  LiveSourceError,
+  LiveSourceChunk,
+  PINNED_SOURCE_SYSTEM_PREFIX,
+  MAX_PINNED_SOURCES,
+  STATUS_BAR_PREFIX,
+} from './live.source.agent.types';
+
+const URL_INPUT = 'https://docs.nextjs.org/v15';
+const PDF_BUFFER = Buffer.from('fake pdf content');
+const PDF_FILENAME = 'nextjs-docs.pdf';
+const SESSION_ID = 'live-abc123';
+const INDEX_NAME = 'tmp-live-abc123';
+const FAKE_VECTOR = Array(1536).fill(0.1);
+
+function makeChunks(count = 3, sourceType: 'url' | 'pdf' = 'url'): LiveSourceChunk[] {
+  return Array.from({ length: count }, (_, i) => ({
+    content: `Chunk ${i} content about Next.js routing and deployment strategies.`,
+    sourceRef: URL_INPUT,
+    sourceType,
+    chunkIndex: i,
+    tokenCount: 20,
+  }));
+}
+
+function makePinnedSource(overrides: Partial<PinnedSource> = {}): PinnedSource {
+  return {
+    id: 'src-001',
+    label: 'docs.nextjs.org/v15',
+    sourceRef: URL_INPUT,
+    sourceType: 'url',
+    sessionId: SESSION_ID,
+    indexName: INDEX_NAME,
+    chunkCount: 3,
+    totalTokens: 60,
+    pinnedAt: new Date().toISOString(),
+    priorityWeight: 1.5,
+    active: true,
+    ...overrides,
+  };
+}
+
+function makeAdapters(
+  overrides: {
+    crawler?: Partial<LiveSourceCrawlerAdapter>;
+    index?: Partial<LiveSourceIndexAdapter>;
+    embed?: Partial<LiveSourceEmbeddingAdapter>;
+    state?: Partial<LiveSourceStateAdapter>;
+    statusBar?: Partial<LiveSourceStatusBarAdapter>;
+  } = {}
+) {
+  const crawler: LiveSourceCrawlerAdapter = {
+    crawlUrl: sinon.stub().resolves(makeChunks(3, 'url')),
+    parsePdf: sinon.stub().resolves(makeChunks(2, 'pdf')),
+    ...overrides.crawler,
+  };
+  const index: LiveSourceIndexAdapter = {
+    createSession: sinon.stub().resolves({ sessionId: SESSION_ID, indexName: INDEX_NAME }),
+    upsertChunks: sinon.stub().resolves({ uploaded: 3 }),
+    search: sinon
+      .stub()
+      .resolves([{ content: 'Relevant chunk text about Next.js routing.', score: 0.92 }]),
+    deleteSession: sinon.stub().resolves(),
+    ...overrides.index,
+  };
+  const embed: LiveSourceEmbeddingAdapter = {
+    embed: sinon.stub().resolves(FAKE_VECTOR),
+    ...overrides.embed,
+  };
+  const state: LiveSourceStateAdapter = {
+    save: sinon.stub().resolves(),
+    load: sinon.stub().resolves([]),
+    ...overrides.state,
+  };
+  const statusBar: LiveSourceStatusBarAdapter = {
+    update: sinon.stub(),
+    clear: sinon.stub(),
+    ...overrides.statusBar,
+  };
+  return { crawler, index, embed, state, statusBar };
+}
+
+function makeAgent(config: LiveSourceAgentConfig = {}, adapters = makeAdapters()): LiveSourceAgent {
+  return new LiveSourceAgent(
+    config,
+    adapters.crawler,
+    adapters.index,
+    adapters.embed,
+    adapters.state,
+    adapters.statusBar
+  );
+}
+
+describe('LiveSourceAgent', () => {
+  describe('constructor', () => {
+    it('creates an instance', () => {
+      const agent = makeAgent();
+      expect(agent).to.be.instanceOf(LiveSourceAgent);
+    });
+
+    it('accepts custom maxPinnedSources', () => {
+      const agent = makeAgent({ maxPinnedSources: 3 });
+      expect(agent).to.be.instanceOf(LiveSourceAgent);
+    });
+
+    it('accepts custom priorityWeight', () => {
+      const agent = makeAgent({ priorityWeight: 2.0 });
+      expect(agent).to.be.instanceOf(LiveSourceAgent);
+    });
+
+    it('accepts enableLogging: false', () => {
+      const agent = makeAgent({ enableLogging: false });
+      expect(agent).to.be.instanceOf(LiveSourceAgent);
+    });
+
+    it('accepts custom topKPerSource and maxInjectedTokens', () => {
+      const agent = makeAgent({ topKPerSource: 5, maxInjectedTokens: 3000 });
+      expect(agent).to.be.instanceOf(LiveSourceAgent);
+    });
+
+    it('works without a statusBar adapter', () => {
+      const adapters = makeAdapters();
+      const agent = new LiveSourceAgent(
+        {},
+        adapters.crawler,
+        adapters.index,
+        adapters.embed,
+        adapters.state
+      );
+      expect(agent).to.be.instanceOf(LiveSourceAgent);
+    });
+  });
+
+  describe('pinSource() — URL input validation', () => {
+    it('throws INVALID_INPUT for empty URL', async () => {
+      const agent = makeAgent();
+      let threw = false;
+      try {
+        await agent.pinSource({ type: 'url', url: '' });
+      } catch (err) {
+        threw = true;
+        expect((err as LiveSourceError).code).to.equal('INVALID_INPUT');
+      }
+      expect(threw).to.be.true;
+    });
+
+    it('throws INVALID_INPUT for non-http URL', async () => {
+      const agent = makeAgent();
+      let threw = false;
+      try {
+        await agent.pinSource({ type: 'url', url: 'ftp://example.com' });
+      } catch (err) {
+        threw = true;
+        expect((err as LiveSourceError).code).to.equal('INVALID_INPUT');
+      }
+      expect(threw).to.be.true;
+    });
+
+    it('throws INVALID_INPUT for malformed URL', async () => {
+      const agent = makeAgent();
+      let threw = false;
+      try {
+        await agent.pinSource({ type: 'url', url: 'not a url' });
+      } catch (err) {
+        threw = true;
+        expect((err as LiveSourceError).code).to.equal('INVALID_INPUT');
+      }
+      expect(threw).to.be.true;
+    });
+
+    it('accepts https:// URL', async () => {
+      const agent = makeAgent();
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(result.source.sourceType).to.equal('url');
+    });
+
+    it('accepts http:// URL', async () => {
+      const agent = makeAgent();
+      const result = await agent.pinSource({ type: 'url', url: 'http://docs.example.com' });
+      expect(result.source.sourceType).to.equal('url');
+    });
+  });
+
+  describe('pinSource() — PDF input validation', () => {
+    it('throws INVALID_INPUT for empty buffer', async () => {
+      const agent = makeAgent();
+      let threw = false;
+      try {
+        await agent.pinSource({ type: 'pdf', buffer: Buffer.alloc(0), filename: 'doc.pdf' });
+      } catch (err) {
+        threw = true;
+        expect((err as LiveSourceError).code).to.equal('INVALID_INPUT');
+      }
+      expect(threw).to.be.true;
+    });
+
+    it('throws INVALID_INPUT for empty filename', async () => {
+      const agent = makeAgent();
+      let threw = false;
+      try {
+        await agent.pinSource({ type: 'pdf', buffer: PDF_BUFFER, filename: '' });
+      } catch (err) {
+        threw = true;
+        expect((err as LiveSourceError).code).to.equal('INVALID_INPUT');
+      }
+      expect(threw).to.be.true;
+    });
+
+    it('accepts valid PDF input', async () => {
+      const agent = makeAgent();
+      const result = await agent.pinSource({
+        type: 'pdf',
+        buffer: PDF_BUFFER,
+        filename: PDF_FILENAME,
+      });
+      expect(result.source.sourceType).to.equal('pdf');
+    });
+  });
+
+  describe('pinSource() — URL crawl flow (AC-2)', () => {
+    it('calls crawlerAdapter.crawlUrl with correct args', async () => {
+      const adapters = makeAdapters();
+      const agent = makeAgent({ crawlDepth: 3, maxPages: 10 }, adapters);
+
+      await agent.pinSource({ type: 'url', url: URL_INPUT });
+
+      expect((adapters.crawler.crawlUrl as sinon.SinonStub).calledOnce).to.be.true;
+      const [url, opts] = (adapters.crawler.crawlUrl as sinon.SinonStub).firstCall.args;
+      expect(url).to.equal(URL_INPUT);
+      expect(opts.depth).to.equal(3);
+      expect(opts.maxPages).to.equal(10);
+    });
+
+    it('calls indexAdapter.createSession', async () => {
+      const adapters = makeAdapters();
+      const agent = makeAgent({}, adapters);
+
+      await agent.pinSource({ type: 'url', url: URL_INPUT });
+
+      expect((adapters.index.createSession as sinon.SinonStub).calledOnce).to.be.true;
+    });
+
+    it('calls indexAdapter.upsertChunks with crawled chunks', async () => {
+      const adapters = makeAdapters();
+      const agent = makeAgent({}, adapters);
+
+      await agent.pinSource({ type: 'url', url: URL_INPUT });
+
+      expect((adapters.index.upsertChunks as sinon.SinonStub).calledOnce).to.be.true;
+      const [sid, chunks] = (adapters.index.upsertChunks as sinon.SinonStub).firstCall.args;
+      expect(sid)
+        .to.be.a('string')
+        .and.match(/^live-/);
+      expect(chunks).to.have.length(3);
+    });
+
+    it('returns PinResult with correct shape', async () => {
+      const agent = makeAgent();
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+
+      expect(result).to.have.all.keys([
+        'source',
+        'refreshed',
+        'chunksIndexed',
+        'pagesCrawled',
+        'durationMs',
+      ]);
+    });
+
+    it('returns refreshed: false for new pin', async () => {
+      const agent = makeAgent();
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(result.refreshed).to.be.false;
+    });
+
+    it('returns chunksIndexed from upsert result', async () => {
+      const adapters = makeAdapters({
+        index: { upsertChunks: sinon.stub().resolves({ uploaded: 7 }) },
+      });
+      const agent = makeAgent({}, adapters);
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(result.chunksIndexed).to.equal(7);
+    });
+
+    it('returns pagesCrawled as distinct sourceRef count', async () => {
+      const chunksMultiPage: LiveSourceChunk[] = [
+        {
+          content: 'a',
+          sourceRef: 'https://docs.nextjs.org/v15/page1',
+          sourceType: 'url',
+          chunkIndex: 0,
+          tokenCount: 5,
+        },
+        {
+          content: 'b',
+          sourceRef: 'https://docs.nextjs.org/v15/page1',
+          sourceType: 'url',
+          chunkIndex: 1,
+          tokenCount: 5,
+        },
+        {
+          content: 'c',
+          sourceRef: 'https://docs.nextjs.org/v15/page2',
+          sourceType: 'url',
+          chunkIndex: 2,
+          tokenCount: 5,
+        },
+      ];
+      const adapters = makeAdapters({
+        crawler: { crawlUrl: sinon.stub().resolves(chunksMultiPage) },
+      });
+      const agent = makeAgent({}, adapters);
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(result.pagesCrawled).to.equal(2);
+    });
+
+    it('returns durationMs >= 0', async () => {
+      const agent = makeAgent();
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(result.durationMs).to.be.gte(0);
+    });
+
+    it('saves sources to stateAdapter', async () => {
+      const adapters = makeAdapters();
+      const agent = makeAgent({}, adapters);
+
+      await agent.pinSource({ type: 'url', url: URL_INPUT });
+
+      expect((adapters.state.save as sinon.SinonStub).calledOnce).to.be.true;
+    });
+
+    it('updates status bar after pin', async () => {
+      const adapters = makeAdapters();
+      const agent = makeAgent({}, adapters);
+
+      await agent.pinSource({ type: 'url', url: URL_INPUT });
+
+      expect((adapters.statusBar.update as sinon.SinonStub).calledOnce).to.be.true;
+    });
+
+    it('derives label from URL hostname when no label provided', async () => {
+      const agent = makeAgent();
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(result.source.label).to.include('docs.nextjs.org');
+    });
+
+    it('uses provided label over derived label', async () => {
+      const agent = makeAgent();
+      const result = await agent.pinSource({
+        type: 'url',
+        url: URL_INPUT,
+        label: 'My Custom Label',
+      });
+      expect(result.source.label).to.equal('My Custom Label');
+    });
+
+    it('sets priorityWeight from config', async () => {
+      const agent = makeAgent({ priorityWeight: 2.0 });
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(result.source.priorityWeight).to.equal(2.0);
+    });
+
+    it('sets pinnedAt as ISO string', async () => {
+      const agent = makeAgent();
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(() => new Date(result.source.pinnedAt)).to.not.throw();
+    });
+
+    it('sets source.active to true', async () => {
+      const agent = makeAgent();
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(result.source.active).to.be.true;
+    });
+  });
+
+  describe('pinSource() — PDF parse flow (AC-2)', () => {
+    it('calls crawlerAdapter.parsePdf with correct args', async () => {
+      const adapters = makeAdapters();
+      const agent = makeAgent({}, adapters);
+
+      await agent.pinSource({ type: 'pdf', buffer: PDF_BUFFER, filename: PDF_FILENAME });
+
+      expect((adapters.crawler.parsePdf as sinon.SinonStub).calledOnce).to.be.true;
+      const [buf, name] = (adapters.crawler.parsePdf as sinon.SinonStub).firstCall.args;
+      expect(buf).to.equal(PDF_BUFFER);
+      expect(name).to.equal(PDF_FILENAME);
+    });
+
+    it('returns pagesCrawled: 0 for PDF', async () => {
+      const agent = makeAgent();
+      const result = await agent.pinSource({
+        type: 'pdf',
+        buffer: PDF_BUFFER,
+        filename: PDF_FILENAME,
+      });
+      expect(result.pagesCrawled).to.equal(0);
+    });
+
+    it('derives label from filename', async () => {
+      const agent = makeAgent();
+      const result = await agent.pinSource({
+        type: 'pdf',
+        buffer: PDF_BUFFER,
+        filename: 'nextjs-docs.pdf',
+      });
+      expect(result.source.label).to.equal('nextjs-docs');
+    });
+  });
+
+  describe('pinSource() — refresh existing pin', () => {
+    it('returns refreshed: true when same sourceRef is re-pinned', async () => {
+      const existing = makePinnedSource();
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([existing]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(result.refreshed).to.be.true;
+    });
+
+    it('preserves original pinnedAt on refresh', async () => {
+      const originalDate = '2026-01-01T00:00:00.000Z';
+      const existing = makePinnedSource({ pinnedAt: originalDate });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([existing]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(result.source.pinnedAt).to.equal(originalDate);
+    });
+
+    it('preserves original id on refresh', async () => {
+      const existing = makePinnedSource({ id: 'original-id' });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([existing]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(result.source.id).to.equal('original-id');
+    });
+
+    it('does not count refresh against quota', async () => {
+      // Fill to max - 1, existing has same sourceRef
+      const sources = Array.from({ length: MAX_PINNED_SOURCES - 1 }, (_, i) =>
+        makePinnedSource({ id: `s-${i}`, sourceRef: `https://other-${i}.com` })
+      );
+      const existing = makePinnedSource({ id: 'existing', sourceRef: URL_INPUT });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([...sources, existing]) },
+      });
+      const agent = makeAgent({ maxPinnedSources: MAX_PINNED_SOURCES }, adapters);
+
+      // Should not throw even though we're at max
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(result.refreshed).to.be.true;
+    });
+  });
+
+  describe('pinSource() — quota enforcement (AC-1 / AC-5 implied)', () => {
+    it('throws MAX_SOURCES_REACHED when at capacity', async () => {
+      const sources = Array.from({ length: MAX_PINNED_SOURCES }, (_, i) =>
+        makePinnedSource({ id: `s-${i}`, sourceRef: `https://source-${i}.com` })
+      );
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves(sources) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      let threw = false;
+      try {
+        await agent.pinSource({ type: 'url', url: 'https://new.example.com' });
+      } catch (err) {
+        threw = true;
+        expect((err as LiveSourceError).code).to.equal('MAX_SOURCES_REACHED');
+      }
+      expect(threw).to.be.true;
+    });
+
+    it('respects custom maxPinnedSources', async () => {
+      const sources = [makePinnedSource({ sourceRef: 'https://other.com' })];
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves(sources) },
+      });
+      const agent = makeAgent({ maxPinnedSources: 1 }, adapters);
+
+      let threw = false;
+      try {
+        await agent.pinSource({ type: 'url', url: 'https://new.example.com' });
+      } catch (err) {
+        threw = true;
+        expect((err as LiveSourceError).code).to.equal('MAX_SOURCES_REACHED');
+      }
+      expect(threw).to.be.true;
+    });
+  });
+
+  describe('pinSource() — error handling', () => {
+    it('throws CRAWL_FAILED when crawlUrl rejects', async () => {
+      const adapters = makeAdapters({
+        crawler: { crawlUrl: sinon.stub().rejects(new Error('network error')) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      let threw = false;
+      try {
+        await agent.pinSource({ type: 'url', url: URL_INPUT });
+      } catch (err) {
+        threw = true;
+        expect((err as LiveSourceError).code).to.equal('CRAWL_FAILED');
+      }
+      expect(threw).to.be.true;
+    });
+
+    it('throws CRAWL_FAILED when crawl returns zero chunks', async () => {
+      const adapters = makeAdapters({
+        crawler: { crawlUrl: sinon.stub().resolves([]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      let threw = false;
+      try {
+        await agent.pinSource({ type: 'url', url: URL_INPUT });
+      } catch (err) {
+        threw = true;
+        expect((err as LiveSourceError).code).to.equal('CRAWL_FAILED');
+      }
+      expect(threw).to.be.true;
+    });
+
+    it('throws INDEX_FAILED when createSession rejects', async () => {
+      const adapters = makeAdapters({
+        index: { createSession: sinon.stub().rejects(new Error('azure fail')) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      let threw = false;
+      try {
+        await agent.pinSource({ type: 'url', url: URL_INPUT });
+      } catch (err) {
+        threw = true;
+        expect((err as LiveSourceError).code).to.equal('INDEX_FAILED');
+      }
+      expect(threw).to.be.true;
+    });
+
+    it('throws INDEX_FAILED when upsertChunks rejects', async () => {
+      const adapters = makeAdapters({
+        index: { upsertChunks: sinon.stub().rejects(new Error('upsert fail')) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      let threw = false;
+      try {
+        await agent.pinSource({ type: 'url', url: URL_INPUT });
+      } catch (err) {
+        threw = true;
+        expect((err as LiveSourceError).code).to.equal('INDEX_FAILED');
+      }
+      expect(threw).to.be.true;
+    });
+
+    it('LiveSourceError carries sourceRef', async () => {
+      const adapters = makeAdapters({
+        crawler: { crawlUrl: sinon.stub().rejects(new Error('fail')) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      let err: LiveSourceError | null = null;
+      try {
+        await agent.pinSource({ type: 'url', url: URL_INPUT });
+      } catch (e) {
+        err = e as LiveSourceError;
+      }
+      expect(err?.sourceRef).to.equal(URL_INPUT);
+    });
+  });
+
+  describe('pinSource() — progress reporting', () => {
+    it('calls progressAdapter.report during crawl', async () => {
+      const agent = makeAgent();
+      const progress: LiveSourceProgressAdapter = { report: sinon.stub() };
+
+      await agent.pinSource({ type: 'url', url: URL_INPUT }, progress);
+
+      expect((progress.report as sinon.SinonStub).called).to.be.true;
+    });
+
+    it('reports at least 3 progress messages', async () => {
+      const agent = makeAgent();
+      const progress: LiveSourceProgressAdapter = { report: sinon.stub() };
+
+      await agent.pinSource({ type: 'url', url: URL_INPUT }, progress);
+
+      expect((progress.report as sinon.SinonStub).callCount).to.be.gte(3);
+    });
+
+    it('works without progress adapter', async () => {
+      const agent = makeAgent();
+      const result = await agent.pinSource({ type: 'url', url: URL_INPUT });
+      expect(result.chunksIndexed).to.be.gte(0);
+    });
+  });
+
+  describe('unpinSource() (AC-6)', () => {
+    it('marks source as inactive', async () => {
+      const source = makePinnedSource({ id: 'src-001' });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      await agent.unpinSource('src-001');
+
+      const list = await agent.listPinnedSources();
+      expect(list).to.have.length(0);
+    });
+
+    it('calls indexAdapter.deleteSession', async () => {
+      const source = makePinnedSource({ id: 'src-001' });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      await agent.unpinSource('src-001');
+
+      expect((adapters.index.deleteSession as sinon.SinonStub).calledOnce).to.be.true;
+      expect((adapters.index.deleteSession as sinon.SinonStub).firstCall.args[0]).to.equal(
+        SESSION_ID
+      );
+    });
+
+    it('saves updated sources to stateAdapter', async () => {
+      const source = makePinnedSource({ id: 'src-001' });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      await agent.unpinSource('src-001');
+
+      expect((adapters.state.save as sinon.SinonStub).called).to.be.true;
+    });
+
+    it('clears status bar when last source is unpinned', async () => {
+      const source = makePinnedSource({ id: 'src-001' });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      await agent.unpinSource('src-001');
+
+      expect((adapters.statusBar.clear as sinon.SinonStub).calledOnce).to.be.true;
+    });
+
+    it('returns wasAlreadyGone: true for unknown id', async () => {
+      const agent = makeAgent();
+      const result = await agent.unpinSource('nonexistent');
+      expect(result.wasAlreadyGone).to.be.true;
+      expect(result.deleted).to.be.true;
+    });
+
+    it('returns deleted: true on success', async () => {
+      const source = makePinnedSource({ id: 'src-001' });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.unpinSource('src-001');
+      expect(result.deleted).to.be.true;
+      expect(result.label).to.equal(source.label);
+    });
+
+    it('sets wasAlreadyGone: true when deleteSession throws (still marks inactive)', async () => {
+      const source = makePinnedSource({ id: 'src-001' });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+        index: { deleteSession: sinon.stub().rejects(new Error('azure fail')) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.unpinSource('src-001');
+      expect(result.wasAlreadyGone).to.be.true;
+    });
+  });
+
+  describe('unpinByRef()', () => {
+    it('unpins by sourceRef', async () => {
+      const source = makePinnedSource({ id: 'src-001', sourceRef: URL_INPUT });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.unpinByRef(URL_INPUT);
+      expect(result.deleted).to.be.true;
+    });
+
+    it('returns wasAlreadyGone: true for unknown sourceRef', async () => {
+      const agent = makeAgent();
+      const result = await agent.unpinByRef('https://unknown.com');
+      expect(result.wasAlreadyGone).to.be.true;
+    });
+  });
+
+  describe('injectContext() — system prompt injection (AC-3 / AC-4)', () => {
+    const BASE_PROMPT = 'You are DevMind, an AI coding assistant.';
+    const QUERY = 'how does Next.js routing work';
+
+    it('returns original prompt unchanged when no sources pinned', async () => {
+      const agent = makeAgent();
+      const result = await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect(result.systemPrompt).to.equal(BASE_PROMPT);
+      expect(result.hasInjection).to.be.false;
+    });
+
+    it('prepends authoritative source header when sources pinned', async () => {
+      const source = makePinnedSource();
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect(result.systemPrompt).to.include(PINNED_SOURCE_SYSTEM_PREFIX.trim());
+    });
+
+    it('includes base prompt after injected context', async () => {
+      const source = makePinnedSource();
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect(result.systemPrompt).to.include(BASE_PROMPT);
+    });
+
+    it('includes source label in injected section', async () => {
+      const source = makePinnedSource({ label: 'Next.js v15 docs' });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect(result.systemPrompt).to.include('Next.js v15 docs');
+    });
+
+    it('sets hasInjection: true when sources contribute chunks', async () => {
+      const source = makePinnedSource();
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect(result.hasInjection).to.be.true;
+    });
+
+    it('sets sourcesUsed >= 1 when chunks returned', async () => {
+      const source = makePinnedSource();
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect(result.sourcesUsed).to.be.gte(1);
+    });
+
+    it('sets chunksInjected >= 1', async () => {
+      const source = makePinnedSource();
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect(result.chunksInjected).to.be.gte(1);
+    });
+
+    it('sets addedTokens > 0 when chunks injected', async () => {
+      const source = makePinnedSource();
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect(result.addedTokens).to.be.greaterThan(0);
+    });
+
+    it('calls indexAdapter.search with query', async () => {
+      const source = makePinnedSource();
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect((adapters.index.search as sinon.SinonStub).calledOnce).to.be.true;
+      const args = (adapters.index.search as sinon.SinonStub).firstCall.args;
+      expect(args[1]).to.equal(QUERY);
+    });
+
+    it('passes topKPerSource to search', async () => {
+      const source = makePinnedSource();
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({ topKPerSource: 7 }, adapters);
+
+      await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      const args = (adapters.index.search as sinon.SinonStub).firstCall.args;
+      expect(args[3]).to.equal(7);
+    });
+
+    it('passes optional queryVector to search', async () => {
+      const source = makePinnedSource();
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      await agent.injectContext({
+        baseSystemPrompt: BASE_PROMPT,
+        query: QUERY,
+        queryVector: FAKE_VECTOR,
+      });
+
+      const args = (adapters.index.search as sinon.SinonStub).firstCall.args;
+      expect(args[2]).to.deep.equal(FAKE_VECTOR);
+    });
+
+    it('skips source non-fatally when search throws', async () => {
+      const source = makePinnedSource();
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+        index: { search: sinon.stub().rejects(new Error('search fail')) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect(result.hasInjection).to.be.false;
+      expect(result.systemPrompt).to.equal(BASE_PROMPT);
+    });
+
+    it('skips source when search returns no hits', async () => {
+      const source = makePinnedSource();
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+        index: { search: sinon.stub().resolves([]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect(result.hasInjection).to.be.false;
+    });
+
+    it('respects maxInjectedTokens cap', async () => {
+      const source = makePinnedSource();
+      const longHits = Array.from({ length: 10 }, (_, i) => ({
+        content: 'x'.repeat(2000),
+        score: 0.9 - i * 0.01,
+      }));
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+        index: { search: sinon.stub().resolves(longHits) },
+      });
+      const agent = makeAgent({ maxInjectedTokens: 100 }, adapters);
+
+      const result = await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect(result.addedTokens).to.be.lessThan(2000);
+    });
+
+    it('does not inject inactive sources', async () => {
+      const inactive = makePinnedSource({ active: false });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([inactive]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect(result.hasInjection).to.be.false;
+      expect((adapters.index.search as sinon.SinonStub).called).to.be.false;
+    });
+
+    it('includes priority weight annotation in injected header (AC-4)', async () => {
+      const source = makePinnedSource({ label: 'Next.js docs', priorityWeight: 2.0 });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.injectContext({ baseSystemPrompt: BASE_PROMPT, query: QUERY });
+
+      expect(result.systemPrompt).to.include('2');
+    });
+  });
+
+  describe('listPinnedSources()', () => {
+    it('returns empty array when nothing pinned', async () => {
+      const agent = makeAgent();
+      const list = await agent.listPinnedSources();
+      expect(list).to.have.length(0);
+    });
+
+    it('returns only active sources', async () => {
+      const active = makePinnedSource({ id: 'a', active: true });
+      const inactive = makePinnedSource({ id: 'b', active: false });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([active, inactive]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const list = await agent.listPinnedSources();
+      expect(list).to.have.length(1);
+      expect(list[0].id).to.equal('a');
+    });
+
+    it('loads from stateAdapter on first call', async () => {
+      const adapters = makeAdapters();
+      const agent = makeAgent({}, adapters);
+
+      await agent.listPinnedSources();
+
+      expect((adapters.state.load as sinon.SinonStub).calledOnce).to.be.true;
+    });
+
+    it('does not call stateAdapter.load twice (cached)', async () => {
+      const adapters = makeAdapters();
+      const agent = makeAgent({}, adapters);
+
+      await agent.listPinnedSources();
+      await agent.listPinnedSources();
+
+      expect((adapters.state.load as sinon.SinonStub).calledOnce).to.be.true;
+    });
+  });
+
+  describe('getSource()', () => {
+    it('returns source by id', async () => {
+      const source = makePinnedSource({ id: 'src-001' });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const result = await agent.getSource('src-001');
+      expect(result?.id).to.equal('src-001');
+    });
+
+    it('returns null for unknown id', async () => {
+      const agent = makeAgent();
+      const result = await agent.getSource('nope');
+      expect(result).to.be.null;
+    });
+  });
+
+  describe('getStatusBarState() (AC-5)', () => {
+    it('returns pinnedCount: 0 when nothing pinned', async () => {
+      const agent = makeAgent();
+      const state = await agent.getStatusBarState();
+      expect(state.pinnedCount).to.equal(0);
+      expect(state.labels).to.have.length(0);
+    });
+
+    it('returns correct pinnedCount', async () => {
+      const sources = [
+        makePinnedSource({ id: 'a', label: 'docs.nextjs.org' }),
+        makePinnedSource({ id: 'b', label: 'react.dev', sourceRef: 'https://react.dev' }),
+      ];
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves(sources) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const state = await agent.getStatusBarState();
+      expect(state.pinnedCount).to.equal(2);
+    });
+
+    it('includes labels of all active sources', async () => {
+      const source = makePinnedSource({ label: 'Next.js v15 docs' });
+      const adapters = makeAdapters({
+        state: { load: sinon.stub().resolves([source]) },
+      });
+      const agent = makeAgent({}, adapters);
+
+      const state = await agent.getStatusBarState();
+      expect(state.labels).to.include('Next.js v15 docs');
+    });
+  });
+
+  describe('buildStatusBarText() (AC-5)', () => {
+    it('returns empty string when no sources', () => {
+      const agent = makeAgent();
+      const text = agent.buildStatusBarText({ pinnedCount: 0, labels: [] });
+      expect(text).to.equal('');
+    });
+
+    it('includes STATUS_BAR_PREFIX pin icon', () => {
+      const agent = makeAgent();
+      const text = agent.buildStatusBarText({ pinnedCount: 1, labels: ['Next.js docs'] });
+      expect(text).to.include(STATUS_BAR_PREFIX);
+    });
+
+    it('shows label for single source', () => {
+      const agent = makeAgent();
+      const text = agent.buildStatusBarText({ pinnedCount: 1, labels: ['Next.js docs'] });
+      expect(text).to.include('Next.js docs');
+      expect(text).to.include('pinned');
+    });
+
+    it('shows count for multiple sources', () => {
+      const agent = makeAgent();
+      const text = agent.buildStatusBarText({ pinnedCount: 3, labels: ['a', 'b', 'c'] });
+      expect(text).to.include('3');
+      expect(text).to.include('docs pinned');
+    });
+  });
+
+  describe('LiveSourceError', () => {
+    it('is an instance of Error', () => {
+      const err = new LiveSourceError('msg', 'INVALID_INPUT');
+      expect(err).to.be.instanceOf(Error);
+    });
+
+    it('carries code', () => {
+      const err = new LiveSourceError('msg', 'CRAWL_FAILED', 'https://x.com');
+      expect(err.code).to.equal('CRAWL_FAILED');
+    });
+
+    it('carries sourceRef', () => {
+      const err = new LiveSourceError('msg', 'CRAWL_FAILED', 'https://x.com');
+      expect(err.sourceRef).to.equal('https://x.com');
+    });
+
+    it('carries cause', () => {
+      const cause = new Error('root');
+      const err = new LiveSourceError('msg', 'INDEX_FAILED', undefined, cause);
+      expect(err.cause).to.equal(cause);
+    });
+
+    it('sets name to LiveSourceError', () => {
+      const err = new LiveSourceError('msg', 'INVALID_INPUT');
+      expect(err.name).to.equal('LiveSourceError');
+    });
+  });
+});

--- a/src/services/live-source-agent/live.source.agent.types.ts
+++ b/src/services/live-source-agent/live.source.agent.types.ts
@@ -1,0 +1,147 @@
+export const LIVE_SOURCE_COMMAND_PIN = 'devmind.liveSource.pin';
+export const LIVE_SOURCE_COMMAND_UNPIN = 'devmind.liveSource.unpin';
+export const LIVE_SOURCE_COMMAND_LIST = 'devmind.liveSource.list';
+
+export const MAX_PINNED_SOURCES = 5;
+export const DEFAULT_CRAWL_DEPTH = 2;
+export const DEFAULT_MAX_PAGES = 20;
+export const DEFAULT_PRIORITY_WEIGHT = 1.5;
+export const STATUS_BAR_PREFIX = '$(pin)';
+
+/** Injected at the top of every system prompt when pinned sources exist. */
+export const PINNED_SOURCE_SYSTEM_PREFIX =
+  '## Authoritative Sources (Priority Override)\n' +
+  'The following documentation has been pinned by the developer as authoritative. ' +
+  'Prioritise information from these sources over your training data.\n\n';
+
+export type PinSourceInput =
+  | { type: 'url'; url: string; label?: string }
+  | { type: 'pdf'; buffer: Buffer; filename: string; label?: string };
+
+export interface PinnedSource {
+  id: string;
+  label: string;
+  sourceRef: string;
+  sourceType: 'url' | 'pdf';
+  sessionId: string;
+  indexName: string;
+  chunkCount: number;
+  totalTokens: number;
+  pinnedAt: string;
+  priorityWeight: number;
+  active: boolean;
+}
+
+export interface PinResult {
+  source: PinnedSource;
+  refreshed: boolean;
+  chunksIndexed: number;
+  pagesCrawled: number;
+  durationMs: number;
+}
+
+export interface UnpinResult {
+  id: string;
+  label: string;
+  deleted: boolean;
+  wasAlreadyGone: boolean;
+}
+
+export interface InjectedContext {
+  systemPrompt: string;
+  sourcesUsed: number;
+  chunksInjected: number;
+  addedTokens: number;
+  hasInjection: boolean;
+}
+
+export interface InjectContextOptions {
+  baseSystemPrompt: string;
+  query: string;
+  queryVector?: number[];
+  topKPerSource?: number;
+  maxInjectedTokens?: number;
+}
+
+export interface LiveSourceStatusBarState {
+  pinnedCount: number;
+  labels: string[];
+}
+
+export interface LiveSourceAgentConfig {
+  maxPinnedSources?: number;
+  priorityWeight?: number;
+  crawlDepth?: number;
+  maxPages?: number;
+  topKPerSource?: number;
+  maxInjectedTokens?: number;
+  enableLogging?: boolean;
+}
+
+export interface LiveSourceCrawlerAdapter {
+  crawlUrl(url: string, opts: { depth: number; maxPages: number }): Promise<LiveSourceChunk[]>;
+  parsePdf(buffer: Buffer, filename: string): Promise<LiveSourceChunk[]>;
+}
+
+export interface LiveSourceChunk {
+  content: string;
+  sourceRef: string;
+  sourceType: 'url' | 'pdf';
+  chunkIndex: number;
+  tokenCount: number;
+}
+
+export interface LiveSourceIndexAdapter {
+  createSession(
+    sessionId: string,
+    label: string
+  ): Promise<{ sessionId: string; indexName: string }>;
+  upsertChunks(sessionId: string, chunks: LiveSourceChunk[]): Promise<{ uploaded: number }>;
+  search(
+    sessionId: string,
+    query: string,
+    vector: number[] | undefined,
+    topK: number
+  ): Promise<Array<{ content: string; score: number }>>;
+
+  deleteSession(sessionId: string): Promise<void>;
+}
+
+export interface LiveSourceEmbeddingAdapter {
+  embed(text: string): Promise<number[]>;
+}
+
+export interface LiveSourceStateAdapter {
+  save(sources: PinnedSource[]): Promise<void>;
+  load(): Promise<PinnedSource[]>;
+}
+
+export interface LiveSourceProgressAdapter {
+  report(message: string, increment?: number): void;
+}
+
+export interface LiveSourceStatusBarAdapter {
+  update(state: LiveSourceStatusBarState): void;
+  clear(): void;
+}
+
+export class LiveSourceError extends Error {
+  constructor(
+    message: string,
+    public readonly code: LiveSourceErrorCode,
+    public readonly sourceRef?: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'LiveSourceError';
+  }
+}
+
+export type LiveSourceErrorCode =
+  | 'INVALID_INPUT'
+  | 'MAX_SOURCES_REACHED'
+  | 'CRAWL_FAILED'
+  | 'INDEX_FAILED'
+  | 'UNPIN_FAILED'
+  | 'SOURCE_NOT_FOUND'
+  | 'INJECT_FAILED';


### PR DESCRIPTION
- pinSource(): URL crawl via crawlerAdapter.crawlUrl() or PDF via parsePdf()
- Refresh: re-pinning same sourceRef reuses sessionId, preserves pinnedAt + id
- Quota: MAX_PINNED_SOURCES=5, throws MAX_SOURCES_REACHED on new pins
- injectContext(): prepends PINNED_SOURCE_SYSTEM_PREFIX + per-source chunk blocks
- Priority weight (default 1.5x) annotated per source in system prompt
- maxInjectedTokens cap (default 2000) prevents prompt bloat
- unpinSource(id) / unpinByRef(ref): marks inactive, deleteSession() non-fatal
- getStatusBarState() + buildStatusBarText(): '$(pin) Next.js docs pinned'
- Multi-source: '$(pin) 3 docs pinned' for count > 1
- LiveSourceStateAdapter: load/save for full persistence across sessions
- LiveSourceProgressAdapter: 3+ progress messages during crawl/index flow
- Commands: devmind.liveSource.pin / unpin / list